### PR TITLE
fix: missing function type when verify

### DIFF
--- a/src/libs/formatConfig.ts
+++ b/src/libs/formatConfig.ts
@@ -25,9 +25,9 @@ export default function formatConfig(
   const type: string = Object.prototype.toString.call(options)
 
   // Block illegal types
-  if (!['[object String]', '[object Object]'].includes(type)) {
+  if (!['[object String]', '[object Object]', '[object Function]'].includes(type)) {
     throw new Error(
-      '[vite-plugin-banner] The options must be a string or an object.'
+      '[vite-plugin-banner] The options must be a string, an object or a callback function.'
     )
   }
 


### PR DESCRIPTION
https://github.com/chengpeiquan/vite-plugin-banner/blob/5e0e6015c17f5b4d5dec2fd8156635c72dd9eed6/src/libs/formatConfig.ts#L28-L32

![image](https://user-images.githubusercontent.com/49258735/198897065-225ba2ca-c7e3-48e9-90bb-a03119a9fe92.png)
